### PR TITLE
Add colorize locked icons script

### DIFF
--- a/dist/colorize-locked.js
+++ b/dist/colorize-locked.js
@@ -1,0 +1,48 @@
+// ==UserScript==
+// @name        Colorize locked icons
+// @namespace   Violentmonkey Scripts
+// @match       https://retroachievements.org/game/*
+// @grant       none
+// @version     1.0
+// @author      Christian Legge
+// @description 7/1/2025, 9:41:56 AM
+// ==/UserScript==
+
+function toggleColor(els) {
+    els.forEach((el) => {
+        const img = el.children[0].children[0].children[0].children[0];
+        if (img.src.endsWith("_lock.png")) {
+            img.src = img.src.replace(/_lock/, "");
+        } else {
+            img.src = img.src.replace(/\.png$/, "_lock.png");
+        }
+    });
+}
+
+(function () {
+    "use strict";
+    const cheevoList = document.querySelectorAll("#set-achievements-list")[0];
+    const preCheevos = cheevoList.previousElementSibling;
+    const lockedCheevos = Array.from(cheevoList.children).filter(
+        (el) => !el.classList.contains("unlocked-row"),
+    );
+    if (lockedCheevos.length === 0) {
+        return;
+    }
+    const colorToggle = document.createElement("label");
+    const colorCheckbox = document.createElement("input");
+    colorCheckbox.setAttribute("type", "checkbox");
+    colorCheckbox.classList.add("cursor-pointer");
+    colorCheckbox.addEventListener("change", () => toggleColor(lockedCheevos));
+    colorToggle.classList.add(
+        "flex",
+        "items-center",
+        "gap-x-1",
+        "select-none",
+        "cursor-pointer",
+    );
+    colorToggle.innerText = "Colorize locked icons";
+    colorToggle.prepend(colorCheckbox);
+
+    setTimeout(preCheevos.children[0].appendChild(colorToggle), 100);
+})();


### PR DESCRIPTION
Adds a userscript to run on game pages to display the unlocked version of achievement icons. Useful for event tasks that care about icon color, or just wanting to see the original icons for any reason. 

https://github.com/user-attachments/assets/b0a44685-25e5-4f84-b030-f6a46b9158ca

